### PR TITLE
Add footer to Layout component

### DIFF
--- a/frontend/src/components/Layout/Layout.js
+++ b/frontend/src/components/Layout/Layout.js
@@ -164,9 +164,28 @@ const Layout = () => {
           p: 3,
           width: { sm: `calc(100% - ${drawerWidth}px)` },
           mt: "64px",
+          display: "flex",
+          flexDirection: "column",
+          minHeight: "calc(100vh - 64px)",
         }}
       >
-        <Outlet />
+        <Box sx={{ flexGrow: 1 }}>
+          <Outlet />
+        </Box>
+        <Box
+          component="footer"
+          sx={{
+            textAlign: "center",
+            py: 2,
+            mt: 3,
+            borderTop: "1px solid",
+            borderColor: "divider",
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            Built with ❤︎ by Keith Ngaira
+          </Typography>
+        </Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
- Add flexbox layout to main content area with flex-direction column
- Set minimum height to fill viewport minus header height (64px)
- Wrap Outlet component in Box with flexGrow: 1 to push footer down
- Add footer component with centered text and top border
- Footer displays "Built with ❤︎ by Keith Ngaira" message
- Apply consistent spacing and styling using Material-UI theme

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4c60d656bbd94b5db6f22b83b2b6d529/zenith-forge)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4c60d656bbd94b5db6f22b83b2b6d529</projectId>-->
<!--<branchName>zenith-forge</branchName>-->